### PR TITLE
Decreased Browser direct download threshold to 5GiB

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/utils.ts
@@ -96,8 +96,8 @@ export const download = (
     path = path.concat(`&version_id=${versionID}`);
   }
 
-  // If file is greater than 50GiB then we force browser download, if not then we use HTTP Request for Object Manager
-  if (fileSize > 53687091200) {
+  // If file is greater than 5GiB then we force browser download, if not then we use HTTP Request for Object Manager
+  if (fileSize > 5368709120) {
     return new BrowserDownload(path, id, completeCallback, toastCallback);
   }
 


### PR DESCRIPTION
fixes https://github.com/minio/object-browser/issues/3539

## What does this do?

Decreased the direct download threshold to 5GiB so browser download manager handles these downloads instead of MinIO Object Manager on slower systems