### PR TITLE
Fix download option in file preview

### DIFF
--- a/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
+++ b/web-app/src/screens/Console/Buckets/ListBuckets/Objects/Preview/PreviewFileContent.tsx
@@ -180,9 +180,9 @@ const PreviewFile = ({
                 path={path}
                 onLoad={iframeLoaded}
                 loading={loading}
-                downloadFile={() =>
-                  downloadObject(dispatch, bucketName, path, actualInfo)
-                }
+                downloadFile={() => {
+                  downloadObject(dispatch, bucketName, objectName, actualInfo);
+                }}
               />
             </Fragment>
           )}


### PR DESCRIPTION
Issue fixed in this PR:

The download button in the file preview model doesn't work

<img width="1326" height="748" alt="image" src="https://github.com/user-attachments/assets/52aecfb0-a2f9-4442-a092-4109b4802fdf" />
